### PR TITLE
Add explicitConsumerTags to Analytics.Event model

### DIFF
--- a/src/main/kotlin/com/trafi/mammoth/CodeGenerator.kt
+++ b/src/main/kotlin/com/trafi/mammoth/CodeGenerator.kt
@@ -33,12 +33,13 @@ object CodeGenerator {
             .addComment("%L schema version %L\n", schema.projectId, schema.versionNumber)
             .addComment("Generated with https://github.com/trafi/mammoth-kt\nDo not edit manually.")
             .addProperty(
-                PropertySpec.builder(
-                    schemaVersionPropertyName,
-                    String::class,
-                    KModifier.PRIVATE,
-                    KModifier.CONST
-                )
+                PropertySpec
+                    .builder(
+                        schemaVersionPropertyName,
+                        String::class,
+                        KModifier.PRIVATE,
+                        KModifier.CONST
+                    )
                     .initializer("%S", schema.versionNumber)
                     .build()
             )
@@ -109,14 +110,13 @@ object CodeGenerator {
     }
 
     private fun generateSdkTags(event: Schema.Event): CodeBlock? {
+        val sdkTags = event.tags.filter {
+            it.clazz.contains(other = "Sdk", ignoreCase = true)
+        }
         return CodeBlock.of(
             "listOf(\n⇥%L⇤\n)",
-            event.tags
-                .filter {
-                    it.clazz.contains(other = "Sdk", ignoreCase = true)
-                }
-                .joinToString(separator = ",\n") { "\"${it.name}\"" }
-        ).takeIf { event.tags.isNotEmpty() }
+            sdkTags.joinToString(separator = ",\n") { "\"${it.name}\"" }
+        ).takeIf { sdkTags.isNotEmpty() }
     }
 
     private fun generatePublishEvent(event: Schema.Event): CodeBlock {
@@ -248,4 +248,3 @@ private val Schema.Event.Parameter.nativeParameterExpression: String
 private val String.normalized: String
     get() = replace(" ", "")
         .split("_").joinToString(separator = "") { it.capitalize() }
-

--- a/src/test/kotlin/CodeGeneratorTests.kt
+++ b/src/test/kotlin/CodeGeneratorTests.kt
@@ -82,7 +82,8 @@ internal class CodeGeneratorTests {
                             "achievement_id" to "0",
                             "score" to mammothSchemaVersion
                         )
-                    )
+                    ),
+                    explicitConsumerTags = null
                 )
             }
 
@@ -98,4 +99,105 @@ internal class CodeGeneratorTests {
         )
     }
 
+    @Test
+    fun `generates function with no parameters but with explicitConsumerTags`() {
+        val schemaJsonString = """
+            {
+              "projectId": "whitelabel",
+              "versionNumber": 1,
+              "events": [
+                {
+                  "id": 0,
+                  "name": "SomeScreenOpen",
+                  "description": "Some screen was opened",
+                  "values": [
+                    {
+                      "parameter": {
+                        "name": "event_type",
+                        "typeName": "event_type",
+                        "description": "",
+                        "publishName": "event_type"
+                      },
+                      "stringValue": null,
+                      "integerValue": null,
+                      "booleanValue": null,
+                      "stringEnumValue": "screen_open"
+                    }
+                  ],
+                  "parameters": [],
+                  "tags": [
+                     {
+                        "name": "Braze",
+                        "class": "Sdk"
+                     },
+                     {
+                        "name": "Batch",
+                        "class": "Sdk"
+                     }
+                  ]
+                }
+              ],
+              "types": [
+                {
+                  "name": "event_type",
+                  "stringEnum": [
+                    "screen_open",
+                    "element_tap"
+                  ]
+                }
+              ]
+            }
+        """.trimIndent()
+        val schema = json.decodeFromString<Schema>(schemaJsonString)
+
+        val code = CodeGenerator.generateCode(schema)
+        assertEquals(
+            """
+            // whitelabel schema version 1
+            // Generated with https://github.com/trafi/mammoth-kt
+            // Do not edit manually.
+            package com.trafi.analytics
+
+            import kotlin.String
+
+            private const val mammothSchemaVersion: String = "1"
+
+            public object AnalyticsEvent {
+                /**
+                 * Some screen was opened
+                 */
+                public fun someScreenOpen(): Analytics.Event = Analytics.Event(
+                    business = RawEvent(
+                        name = "SomeScreenOpen",
+                        parameters = mapOf(
+                            "event_type" to "screen_open",
+                            "schema_event_id" to "0",
+                            "schema_version" to mammothSchemaVersion
+                        )
+                    ),
+                    publish = RawEvent(
+                        name = "screen_open",
+                        parameters = mapOf(
+                            "achievement_id" to "0",
+                            "score" to mammothSchemaVersion
+                        )
+                    ),
+                    explicitConsumerTags = listOf(
+                        "Braze",
+                        "Batch"
+                    )
+                )
+            }
+
+            public enum class EventType(
+                public val value: String
+            ) {
+                SCREEN_OPEN("screen_open"),
+                ELEMENT_TAP("element_tap"),
+                ;
+            }
+            
+            """.trimIndent(), code
+        )
+    }
 }


### PR DESCRIPTION
The idea was to add `explicitConsumerTags` to each `Analytics.Event` model so I could check if this particular event has restrictions related to analytics consumer.
For example:

`BatchPurchaseTicket` event has 2 tags in mammoth console: `Sdk: Braze` & `Sdk: Batch`
so `Analytics.Event` will have explicitConsumerTags = listOf("Batch", "Braze") and using this data, I can make sure, that `FirebaseAnalyticsConsumer` or `MParticleAnalyticsConsumer` will not log them
```
class MParticleAnalyticsConsumer : AnalyticsConsumer {
   override fun track(event: Analytics.Event){
      if(event. explicitConsumerTags.isNotEmpty()) return
      ... 
   }
}
```

If event has no tags related to consumer restrictions, then it means, that default(main) analytics consumer can track them 