### PR TITLE
Support customization of output class name and schema metadata inclusion

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "com.trafi"
-version = "2.1"
+version = "2.2"
 
 dependencies {
     implementation(libs.kotlin.stdlib)

--- a/src/main/kotlin/Mammoth.kt
+++ b/src/main/kotlin/Mammoth.kt
@@ -17,6 +17,7 @@ class Mammoth : CliktCommand() {
     private val version: String by option(help = "Mammoth schema version").default("")
     private val outputPath: String by option(help = "Generated schema code output path").default("")
     private val outputFilename: String by option(help = "Generated schema code output file name").default("MammothEvents.kt")
+    private val outputClassName: String by option(help = "Generated schema code output class name").default("AnalyticsEvent")
 
     override fun run() {
         try {
@@ -37,7 +38,7 @@ class Mammoth : CliktCommand() {
             val schema = json.decodeFromString<Schema>(schemaJsonString)
 
             echo(if (business) "Generating code" else "Cooking kotlet")
-            val code = CodeGenerator.generateCode(schema)
+            val code = CodeGenerator.generateCode(schema, outputClassName)
 
             val file = File(outputPath).resolve(outputFilename)
             echo(if (business) "Writing generated code to $file" else "Serving hot kotlet at $file")

--- a/src/main/kotlin/Mammoth.kt
+++ b/src/main/kotlin/Mammoth.kt
@@ -1,5 +1,6 @@
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.parameters.options.default
+import com.github.ajalt.clikt.parameters.options.flag
 import com.github.ajalt.clikt.parameters.options.option
 import com.trafi.mammoth.CodeGenerator
 import com.trafi.mammoth.Schema
@@ -18,6 +19,8 @@ class Mammoth : CliktCommand() {
     private val outputPath: String by option(help = "Generated schema code output path").default("")
     private val outputFilename: String by option(help = "Generated schema code output file name").default("MammothEvents.kt")
     private val outputClassName: String by option(help = "Generated schema code output class name").default("AnalyticsEvent")
+    private val includeSchemaMetadata: Boolean by option(help = "Include schema version & event id in generated event parameters")
+        .flag("--no-schema-metadata", default = true, defaultForHelp = "include")
 
     override fun run() {
         try {
@@ -38,7 +41,7 @@ class Mammoth : CliktCommand() {
             val schema = json.decodeFromString<Schema>(schemaJsonString)
 
             echo(if (business) "Generating code" else "Cooking kotlet")
-            val code = CodeGenerator.generateCode(schema, outputClassName)
+            val code = CodeGenerator.generateCode(schema, outputClassName, includeSchemaMetadata)
 
             val file = File(outputPath).resolve(outputFilename)
             echo(if (business) "Writing generated code to $file" else "Serving hot kotlet at $file")

--- a/src/main/kotlin/com/trafi/mammoth/CodeGenerator.kt
+++ b/src/main/kotlin/com/trafi/mammoth/CodeGenerator.kt
@@ -29,8 +29,8 @@ object CodeGenerator {
     private val rawEventClass = ClassName(packageName, "RawEvent")
     private val schemaVersion = MemberName(packageName, schemaVersionPropertyName)
 
-    fun generateCode(schema: Schema): String {
-        val file = FileSpec.builder(packageName, "AnalyticsEvent")
+    fun generateCode(schema: Schema, className: String): String {
+        val file = FileSpec.builder(packageName, className)
             .indent("    ")
             .addFileComment("%L schema version %L\n", schema.projectId, schema.versionNumber)
             .addFileComment("Generated with https://github.com/trafi/mammoth-kt\nDo not edit manually.")
@@ -46,7 +46,7 @@ object CodeGenerator {
                     .build()
             )
             .addType(
-                TypeSpec.objectBuilder("AnalyticsEvent")
+                TypeSpec.objectBuilder(className)
                     .apply { schema.events.forEach { addFunction(generateEventFunction(it)) } }
                     .build()
             )

--- a/src/main/kotlin/com/trafi/mammoth/CodeGenerator.kt
+++ b/src/main/kotlin/com/trafi/mammoth/CodeGenerator.kt
@@ -113,7 +113,7 @@ object CodeGenerator {
                     .build()
             }.sortedBy { it.defaultValue != null })
             .addStatement(
-                "return %T(\n⇥business = %L,\npublish = %L,\nexplicitConsumerTags = %L⇤\n)",
+                "return %T(\n⇥business = %L,\npublish = %L,\nexplicitConsumerTags = %L,⇤\n)",
                 eventClass,
                 generateBusinessEvent(event, includeSchemaMetadata),
                 generatePublishEvent(event, includeSchemaMetadata) ?: "null",
@@ -128,7 +128,7 @@ object CodeGenerator {
         }
         return CodeBlock.of(
             "listOf(\n⇥%L⇤\n)",
-            sdkTags.joinToString(separator = ",\n") { "\"${it.name}\"" }
+            sdkTags.joinToString(separator = ",\n", postfix = ",") { "\"${it.name}\"" }
         ).takeIf { sdkTags.isNotEmpty() }
     }
 
@@ -179,7 +179,7 @@ object CodeGenerator {
 
     private fun generateRawEvent(name: String, parameterCodeBlocks: List<CodeBlock>): CodeBlock {
         return CodeBlock.of(
-            "%T(\n⇥name = %S,\nparameters = %L⇤\n)",
+            "%T(\n⇥name = %S,\nparameters = %L,⇤\n)",
             rawEventClass,
             name,
             if (parameterCodeBlocks.isEmpty()) {
@@ -187,7 +187,7 @@ object CodeGenerator {
             } else {
                 CodeBlock.of(
                     "mapOf(\n⇥%L⇤\n)",
-                    parameterCodeBlocks.joinToCode(separator = ",\n")
+                    parameterCodeBlocks.joinToCode(separator = ",\n", suffix = ",")
                 )
             }
         )

--- a/src/main/kotlin/com/trafi/mammoth/CodeGenerator.kt
+++ b/src/main/kotlin/com/trafi/mammoth/CodeGenerator.kt
@@ -29,25 +29,33 @@ object CodeGenerator {
     private val rawEventClass = ClassName(packageName, "RawEvent")
     private val schemaVersion = MemberName(packageName, schemaVersionPropertyName)
 
-    fun generateCode(schema: Schema, className: String): String {
+    fun generateCode(schema: Schema, className: String, includeSchemaMetadata: Boolean): String {
         val file = FileSpec.builder(packageName, className)
             .indent("    ")
             .addFileComment("%L schema version %L\n", schema.projectId, schema.versionNumber)
             .addFileComment("Generated with https://github.com/trafi/mammoth-kt\nDo not edit manually.")
-            .addProperty(
-                PropertySpec
-                    .builder(
-                        schemaVersionPropertyName,
-                        String::class,
-                        KModifier.PRIVATE,
-                        KModifier.CONST
+            .apply {
+                if (includeSchemaMetadata) {
+                    addProperty(
+                        PropertySpec
+                            .builder(
+                                schemaVersionPropertyName,
+                                String::class,
+                                KModifier.PRIVATE,
+                                KModifier.CONST
+                            )
+                            .initializer("%S", schema.versionNumber)
+                            .build()
                     )
-                    .initializer("%S", schema.versionNumber)
-                    .build()
-            )
+                }
+            }
             .addType(
                 TypeSpec.objectBuilder(className)
-                    .apply { schema.events.forEach { addFunction(generateEventFunction(it)) } }
+                    .apply {
+                        schema.events.forEach {
+                            addFunction(generateEventFunction(it, includeSchemaMetadata))
+                        }
+                    }
                     .build()
             )
             .apply { schema.types.forEach { generateType(it)?.let { typeSpec -> addType(typeSpec) } } }
@@ -80,7 +88,10 @@ object CodeGenerator {
         }
     }
 
-    private fun generateEventFunction(event: Schema.Event): FunSpec {
+    private fun generateEventFunction(
+        event: Schema.Event,
+        includeSchemaMetadata: Boolean,
+    ): FunSpec {
         return FunSpec.builder(event.nativeFunctionName)
             .addKdoc(event.description)
             .returns(eventClass)
@@ -104,8 +115,8 @@ object CodeGenerator {
             .addStatement(
                 "return %T(\n⇥business = %L,\npublish = %L,\nexplicitConsumerTags = %L⇤\n)",
                 eventClass,
-                generateBusinessEvent(event),
-                generatePublishEvent(event) ?: "null",
+                generateBusinessEvent(event, includeSchemaMetadata),
+                generatePublishEvent(event, includeSchemaMetadata) ?: "null",
                 generateSdkTags(event) ?: "null"
             )
             .build()
@@ -121,7 +132,10 @@ object CodeGenerator {
         ).takeIf { sdkTags.isNotEmpty() }
     }
 
-    private fun generatePublishEvent(event: Schema.Event): CodeBlock? {
+    private fun generatePublishEvent(
+        event: Schema.Event,
+        includeSchemaMetadata: Boolean,
+    ): CodeBlock? {
         val publishName = event.publishName ?: return null
         return generateRawEvent(
             name = publishName,
@@ -137,11 +151,14 @@ object CodeGenerator {
                     it.first,
                     it.second
                 )
-            }).plus(event.publishMetadataParameters)
+            }).let { if (includeSchemaMetadata) it.plus(event.publishMetadataParameters) else it }
         )
     }
 
-    private fun generateBusinessEvent(event: Schema.Event): CodeBlock {
+    private fun generateBusinessEvent(
+        event: Schema.Event,
+        includeSchemaMetadata: Boolean,
+    ): CodeBlock {
         return generateRawEvent(
             name = event.name,
             parameterCodeBlocks = event.businessValues.map {
@@ -156,7 +173,7 @@ object CodeGenerator {
                     it.first,
                     it.second
                 )
-            }).plus(event.businessMetadataParameters)
+            }).let { if (includeSchemaMetadata) it.plus(event.businessMetadataParameters) else it }
         )
     }
 
@@ -165,10 +182,14 @@ object CodeGenerator {
             "%T(\n⇥name = %S,\nparameters = %L⇤\n)",
             rawEventClass,
             name,
-            CodeBlock.of(
-                "mapOf(\n⇥%L⇤\n)",
-                parameterCodeBlocks.joinToCode(separator = ",\n")
-            )
+            if (parameterCodeBlocks.isEmpty()) {
+                CodeBlock.of("mapOf()")
+            } else {
+                CodeBlock.of(
+                    "mapOf(\n⇥%L⇤\n)",
+                    parameterCodeBlocks.joinToCode(separator = ",\n")
+                )
+            }
         )
     }
 

--- a/src/test/kotlin/CodeGeneratorTests.kt
+++ b/src/test/kotlin/CodeGeneratorTests.kt
@@ -199,4 +199,58 @@ internal class CodeGeneratorTests {
             """.trimIndent(), code
         )
     }
+
+    @Test
+    fun `generates function for bare-bones schema`() {
+        val schemaJsonString = """
+            {
+              "projectId": "some-project",
+              "versionNumber": 1,
+              "events": [
+                {
+                  "id": 0,
+                  "name": "SomeScreenOpen",
+                  "description": "Some screen was opened",
+                  "values": [],
+                  "parameters": [],
+                  "tags": []
+                }
+              ],
+              "types": []
+            }
+        """.trimIndent()
+        val schema = json.decodeFromString<Schema>(schemaJsonString)
+
+        val code = CodeGenerator.generateCode(schema, className = "AnalyticsEvent")
+        assertEquals(
+            """
+            // some-project schema version 1
+            // Generated with https://github.com/trafi/mammoth-kt
+            // Do not edit manually.
+            package com.trafi.analytics
+
+            import kotlin.String
+
+            private const val mammothSchemaVersion: String = "1"
+
+            public object AnalyticsEvent {
+                /**
+                 * Some screen was opened
+                 */
+                public fun someScreenOpen(): Analytics.Event = Analytics.Event(
+                    business = RawEvent(
+                        name = "SomeScreenOpen",
+                        parameters = mapOf(
+                            "schema_event_id" to "0",
+                            "schema_version" to mammothSchemaVersion
+                        )
+                    ),
+                    publish = null,
+                    explicitConsumerTags = null
+                )
+            }
+            
+            """.trimIndent(), code
+        )
+    }
 }

--- a/src/test/kotlin/CodeGeneratorTests.kt
+++ b/src/test/kotlin/CodeGeneratorTests.kt
@@ -99,7 +99,7 @@ internal class CodeGeneratorTests {
     }
 
     @Test
-    fun `generates function with no parameters but with explicitConsumerTags`() {
+    fun `generates event with explicitConsumerTags`() {
         val schemaJsonString = """
             {
               "projectId": "whitelabel",

--- a/src/test/kotlin/CodeGeneratorTests.kt
+++ b/src/test/kotlin/CodeGeneratorTests.kt
@@ -76,17 +76,17 @@ internal class CodeGeneratorTests {
                         parameters = mapOf(
                             "event_type" to "screen_open",
                             "schema_event_id" to "0",
-                            "schema_version" to mammothSchemaVersion
-                        )
+                            "schema_version" to mammothSchemaVersion,
+                        ),
                     ),
                     publish = RawEvent(
                         name = "screen_open",
                         parameters = mapOf(
                             "achievement_id" to "0",
-                            "score" to mammothSchemaVersion
-                        )
+                            "score" to mammothSchemaVersion,
+                        ),
                     ),
-                    explicitConsumerTags = null
+                    explicitConsumerTags = null,
                 )
             }
 
@@ -179,20 +179,20 @@ internal class CodeGeneratorTests {
                         parameters = mapOf(
                             "event_type" to "screen_open",
                             "schema_event_id" to "0",
-                            "schema_version" to mammothSchemaVersion
-                        )
+                            "schema_version" to mammothSchemaVersion,
+                        ),
                     ),
                     publish = RawEvent(
                         name = "screen_open",
                         parameters = mapOf(
                             "achievement_id" to "0",
-                            "score" to mammothSchemaVersion
-                        )
+                            "score" to mammothSchemaVersion,
+                        ),
                     ),
                     explicitConsumerTags = listOf(
                         "Braze",
-                        "Batch"
-                    )
+                        "Batch",
+                    ),
                 )
             }
 
@@ -248,10 +248,10 @@ internal class CodeGeneratorTests {
                 public fun someScreenOpen(): Analytics.Event = Analytics.Event(
                     business = RawEvent(
                         name = "SomeScreenOpen",
-                        parameters = mapOf()
+                        parameters = mapOf(),
                     ),
                     publish = null,
-                    explicitConsumerTags = null
+                    explicitConsumerTags = null,
                 )
             }
             

--- a/src/test/kotlin/CodeGeneratorTests.kt
+++ b/src/test/kotlin/CodeGeneratorTests.kt
@@ -50,7 +50,11 @@ internal class CodeGeneratorTests {
         """.trimIndent()
         val schema = json.decodeFromString<Schema>(schemaJsonString)
 
-        val code = CodeGenerator.generateCode(schema, className = "AnalyticsEvent")
+        val code = CodeGenerator.generateCode(
+            schema,
+            className = "AnalyticsEvent",
+            includeSchemaMetadata = true,
+        )
         assertEquals(
             """
             // whitelabel schema version 1
@@ -149,7 +153,11 @@ internal class CodeGeneratorTests {
         """.trimIndent()
         val schema = json.decodeFromString<Schema>(schemaJsonString)
 
-        val code = CodeGenerator.generateCode(schema, className = "AnalyticsEvent")
+        val code = CodeGenerator.generateCode(
+            schema,
+            className = "AnalyticsEvent",
+            includeSchemaMetadata = true,
+        )
         assertEquals(
             """
             // whitelabel schema version 1
@@ -221,17 +229,17 @@ internal class CodeGeneratorTests {
         """.trimIndent()
         val schema = json.decodeFromString<Schema>(schemaJsonString)
 
-        val code = CodeGenerator.generateCode(schema, className = "AnalyticsEvent")
+        val code = CodeGenerator.generateCode(
+            schema,
+            className = "AnalyticsEvent",
+            includeSchemaMetadata = false,
+        )
         assertEquals(
             """
             // some-project schema version 1
             // Generated with https://github.com/trafi/mammoth-kt
             // Do not edit manually.
             package com.trafi.analytics
-
-            import kotlin.String
-
-            private const val mammothSchemaVersion: String = "1"
 
             public object AnalyticsEvent {
                 /**
@@ -240,10 +248,7 @@ internal class CodeGeneratorTests {
                 public fun someScreenOpen(): Analytics.Event = Analytics.Event(
                     business = RawEvent(
                         name = "SomeScreenOpen",
-                        parameters = mapOf(
-                            "schema_event_id" to "0",
-                            "schema_version" to mammothSchemaVersion
-                        )
+                        parameters = mapOf()
                     ),
                     publish = null,
                     explicitConsumerTags = null

--- a/src/test/kotlin/CodeGeneratorTests.kt
+++ b/src/test/kotlin/CodeGeneratorTests.kt
@@ -50,7 +50,7 @@ internal class CodeGeneratorTests {
         """.trimIndent()
         val schema = json.decodeFromString<Schema>(schemaJsonString)
 
-        val code = CodeGenerator.generateCode(schema)
+        val code = CodeGenerator.generateCode(schema, className = "AnalyticsEvent")
         assertEquals(
             """
             // whitelabel schema version 1
@@ -149,7 +149,7 @@ internal class CodeGeneratorTests {
         """.trimIndent()
         val schema = json.decodeFromString<Schema>(schemaJsonString)
 
-        val code = CodeGenerator.generateCode(schema)
+        val code = CodeGenerator.generateCode(schema, className = "AnalyticsEvent")
         assertEquals(
             """
             // whitelabel schema version 1


### PR DESCRIPTION
Introduce new CLI parameters
- `--output-class-name` — generated class name
- `--no-schema-metadata` — do not include schema metadata in generated event parameters

Behavior changes
- support Mammoth event schemas without an `event_type` parameter — no `publish` events will be generated in such cases
- code is generated with trailing commas