### PR TITLE
Bump version to 2.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "com.trafi"
-version = "2.0"
+version = "2.1"
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
We've been using a version of the generator distinct from [the previous 2.0 release](https://github.com/trafi/mammoth-kt/releases/tag/2.0).