### PR TITLE
Take other publishName params

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,13 +18,17 @@ dependencies {
     testRuntimeOnly(libs.junit.jupiter.engine)
 }
 
+kotlin {
+    jvmToolchain(17)
+}
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(17))
+    }
+}
+
 tasks {
-    compileKotlin {
-        kotlinOptions.jvmTarget = "17"
-    }
-    compileTestKotlin {
-        kotlinOptions.jvmTarget = "17"
-    }
     test {
         useJUnitPlatform()
     }

--- a/src/main/kotlin/com/trafi/mammoth/CodeGenerator.kt
+++ b/src/main/kotlin/com/trafi/mammoth/CodeGenerator.kt
@@ -240,6 +240,9 @@ private val Schema.Event.publishName: String?
             values.firstOrNull { it.parameter.name == Schema.Event.Parameter.eventTypeParameterName }
                 ?: return null
         return eventTypeValue.stringEnumValue
+            ?: eventTypeValue.stringValue
+            ?: eventTypeValue.integerValue?.toString()
+            ?: eventTypeValue.booleanValue?.toString()
             ?: throw IllegalArgumentException("${Schema.Event.Parameter.eventTypeParameterName} must have non-null value")
     }
 


### PR DESCRIPTION
We had a problem while generating generateStibSfmcMammoth events, because in STIB project publishName will be just string and not stringEnumValue: 
```
 {
   ....
        {
          "parameter": {
            "name": "event_type",
            "typeName": "String",
            "description": "Event category denoting the object and action being performed on it.",
            "publishName": "event_name"
          },
          "**stringValue**": "bg",
          "integerValue": null,
          "stringEnumValue": null,
          "booleanValue": null
        }
      ],
   ....
```

so added support for other types